### PR TITLE
Batch endpoint for fetching multiple workouts by Id, 'GetWorkoutsByIds'

### DIFF
--- a/API/Controllers/WorkoutController.cs
+++ b/API/Controllers/WorkoutController.cs
@@ -32,6 +32,26 @@ public class WorkoutController(IWorkoutService workoutService) : ControllerBase
             : NotFound();
     }
 
+    [HttpGet("batch")]
+    public async Task<IActionResult> GetWorkoutsByIds([FromQuery] string? ids)
+    {
+
+        var idList = string.IsNullOrWhiteSpace(ids) ? [] : ids.Split(',')
+          .Select(s => s.Trim())
+          .Where(s => s.Length > 0)
+          .ToList();
+
+        if (idList.Count == 0)
+              return BadRequest("ids is required");
+
+        var result = await _workoutService.GetManyWorkoutsByExpressionAsync(x => idList.Contains(x.Id));
+
+        if (!result.Success)
+            return StatusCode(500, result.Error ?? "Failed to fetch workouts.");
+
+        return Ok(result.Result ?? []);
+    }
+
     [HttpPost]
     public async Task<IActionResult> CreateWorkout([FromBody] WorkoutCreationRequest request)
     {

--- a/Business/Interfaces/IWorkoutService.cs
+++ b/Business/Interfaces/IWorkoutService.cs
@@ -11,5 +11,6 @@ namespace Business.Interfaces
         Task<WorkoutResult<WorkoutResponseModel>> GetWorkoutByExpressionAsync(Expression<Func<WorkoutEntity, bool>> expression);
         Task<WorkoutResult> UpdateWorkoutAsync(string id, WorkoutCreationRequest updateRequest);
         Task<WorkoutResult> DeleteEventAsync(string id);
+        Task<WorkoutResult<IEnumerable<WorkoutResponseModel>>> GetManyWorkoutsByExpressionAsync(Expression<Func<WorkoutEntity, bool>> expression);
     }
 }

--- a/Business/Services/WorkoutService.cs
+++ b/Business/Services/WorkoutService.cs
@@ -90,6 +90,39 @@ public class WorkoutService(IWorkoutRepository workoutRepository) : IWorkoutServ
         };
     }
 
+    public async Task<WorkoutResult<IEnumerable<WorkoutResponseModel>>> GetManyWorkoutsByExpressionAsync(Expression<Func<WorkoutEntity, bool>> expression)
+    {
+        try
+        {
+            var repositoryResult = await _workoutRepository.GetManyAsync(expression);
+
+            if (!repositoryResult.Success || repositoryResult.Result == null)
+            {
+                return new WorkoutResult<IEnumerable<WorkoutResponseModel>>
+                {
+                    Success = false,
+                    Error = repositoryResult.Error ?? "No data returned from repository."
+                };
+            }
+
+            var models = repositoryResult.Result.Select(x => x.MapTo<WorkoutResponseModel>()).ToList();
+
+            return new WorkoutResult<IEnumerable<WorkoutResponseModel>>
+            {
+                Success = true,
+                Result = models
+            };
+        }
+        catch (Exception ex)
+        {
+            return new WorkoutResult<IEnumerable<WorkoutResponseModel>>
+            {
+                Success = false,
+                Error = ex.Message
+            };
+        }
+    }
+
 
     public async Task<WorkoutResult> UpdateWorkoutAsync(string id, WorkoutCreationRequest updateRequest)
     {

--- a/Data/Interfaces/IBaseRepository.cs
+++ b/Data/Interfaces/IBaseRepository.cs
@@ -8,6 +8,7 @@ namespace Data.Interfaces
         Task<RepositoryResult> DeleteAsync(TEntity entity);
         Task<RepositoryResult<IEnumerable<TEntity>>> GetAllAsync();
         Task<RepositoryResult<TEntity?>> GetAsync(Expression<Func<TEntity, bool>> expression);
+        Task<RepositoryResult<IEnumerable<TEntity>>> GetManyAsync(Expression<Func<TEntity, bool>> expression);
         Task<RepositoryResult> UpdateAsync(TEntity entity);
     }
 }

--- a/Data/Repositories/BaseRepository.cs
+++ b/Data/Repositories/BaseRepository.cs
@@ -66,6 +66,29 @@ public abstract partial class BaseRepository<TEntity>(DataContext context) : IBa
         }
     }
 
+    public virtual async Task<RepositoryResult<IEnumerable<TEntity>>> GetManyAsync(Expression<Func<TEntity, bool>> expression)
+    {
+        try
+        {
+            var entities = await _table.Where(expression).ToListAsync();
+
+            return new RepositoryResult<IEnumerable<TEntity>> 
+            { 
+                Success = true, 
+                Result = entities 
+            };
+
+        }
+        catch (Exception ex)
+        {
+            return new RepositoryResult<IEnumerable<TEntity>>
+            { 
+                Success = false,
+                Error = ex.Message
+            };
+        }
+    }
+
     public virtual async Task<RepositoryResult> UpdateAsync(TEntity entity)
     {
         try


### PR DESCRIPTION
- New API endpoint: GET /api/workout/batch?ids=id1,id2
- Accepts comma-separated workout IDs; trims whitespace and ignores empty items
- Returns 200 OK with list (empty array allowed — frontend can show "You have no booked workouts")
- 400 if 'ids' is missing, 500 on internal error